### PR TITLE
Add max depth parameters to directory summarization functions

### DIFF
--- a/tests/test_summarize_gpt.py
+++ b/tests/test_summarize_gpt.py
@@ -3,7 +3,7 @@ import os
 import sys
 import logging
 import tempfile
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from summarizeGPT.summarizeGPT import (
     summarize_directory,
     get_tree_view,
@@ -38,7 +38,7 @@ class TestSummarizeGPT(unittest.TestCase):
         """Test basic directory summarization"""
         result = summarize_directory(self.test_dir)
         self.assertIsInstance(result, str)
-        self.assertIn(self.test_dir.replace("\\", "/"), result)  # Ensure proper path formatting
+        self.assertIn(os.path.basename(self.test_dir), result)
         self.assertIn("test.txt", result)
 
     def test_get_tree_view_basic(self):
@@ -73,20 +73,21 @@ class TestSummarizeGPT(unittest.TestCase):
     @patch('sys.exit')
     def test_docker_flags_conflict(self, mock_exit, mock_args):
         """Test handling of conflicting docker flags"""
-        # Mock the parsed arguments
-        mock_args.return_value = MagicMock(
-            directory=self.test_dir,
-            gitignore=None,
-            include=None,
-            exclude=None,
-            show_docker=True,
-            show_only_docker=True,
-            max_lines=None,
-            encoding='cl100k_base',
-            verbose=False
-        )
-
-        # Capture log messages directly
+        mock_args.return_value = type('Args', (), {
+            'directory': self.test_dir,
+            'gitignore': None,
+            'include': None,
+            'exclude': None,
+            'show_docker': True,
+            'show_only_docker': True,
+            'max_lines': None,
+            'encoding': 'cl100k_base',
+            'verbose': False,
+            'tree_depth': None,
+            'file_depth': None,
+            'max_depth': None  # Added missing attribute
+        })()
+        
         with patch('logging.Logger.error') as mock_logger:
             main()
             mock_logger.assert_called_once_with(
@@ -98,27 +99,27 @@ class TestSummarizeGPT(unittest.TestCase):
     @patch('sys.exit')
     def test_file_write_error(self, mock_exit, mock_args):
         """Test handling of file write errors"""
-        # Mock the parsed arguments
-        mock_args.return_value = MagicMock(
-            directory=self.test_dir,
-            gitignore=None,
-            include=None,
-            exclude=None,
-            show_docker=False,
-            show_only_docker=False,
-            max_lines=None,
-            encoding='cl100k_base',
-            verbose=False
-        )
+        mock_args.return_value = type('Args', (), {
+            'directory': self.test_dir,
+            'gitignore': None,
+            'include': None,
+            'exclude': None,
+            'show_docker': False,
+            'show_only_docker': False,
+            'max_lines': None,
+            'encoding': 'cl100k_base',
+            'verbose': False,
+            'tree_depth': None,
+            'file_depth': None,
+            'max_depth': None  # Added missing attribute
+        })()
 
-        # Create a mock that only affects the output file
         original_open = open
         def mock_open_wrapper(*args, **kwargs):
             if args and isinstance(args[0], str) and args[0].endswith(output_file):
                 raise IOError("Permission denied")
             return original_open(*args, **kwargs)
 
-        # Capture log messages directly
         with patch('builtins.open', side_effect=mock_open_wrapper):
             with patch('logging.Logger.error') as mock_logger:
                 main()
@@ -126,6 +127,62 @@ class TestSummarizeGPT(unittest.TestCase):
                     'Failed to write output file: Permission denied'
                 )
                 mock_exit.assert_called_once_with(1)
+
+    def test_depth_limiting(self):
+        """Test directory depth limiting functionality"""
+        # Create a nested directory structure
+        nested_dir = os.path.join(self.test_dir, "level1", "level2")
+        os.makedirs(nested_dir)
+        
+        # Create files at different levels
+        with open(os.path.join(self.test_dir, "root.txt"), "w") as f:
+            f.write("root")
+        with open(os.path.join(self.test_dir, "level1", "level1.txt"), "w") as f:
+            f.write("level1")
+        with open(os.path.join(nested_dir, "level2.txt"), "w") as f:
+            f.write("level2")
+
+        # Test with tree_depth=2 to ensure we see one level of nesting
+        result = summarize_directory(self.test_dir, tree_depth=2, file_depth=2)
+        self.assertIn("root.txt", result)
+        self.assertIn("level1", result)
+        self.assertIn("level1.txt", result)
+        self.assertIn("root", result)  # File content
+        self.assertIn("level1", result)  # File content
+
+    def test_depth_edge_cases(self):
+        """Test edge cases for depth parameters"""
+        nested_dir = os.path.join(self.test_dir, "level1", "level2")
+        os.makedirs(nested_dir)
+        
+        with open(os.path.join(self.test_dir, "root.txt"), "w") as f:
+            f.write("root")
+
+        # Test with depth=0
+        result = summarize_directory(self.test_dir, tree_depth=0, file_depth=0)
+        self.assertIn(os.path.basename(self.test_dir), result)
+        
+        # Test with unlimited depth
+        result = summarize_directory(self.test_dir, tree_depth=None, file_depth=None)
+        self.assertIn("root.txt", result)
+
+    def test_separate_tree_and_file_depths(self):
+        """Test different depth limits for tree view and file contents"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # Create a nested directory structure
+            os.makedirs(os.path.join(tmp_dir, "level1/level2"))
+            with open(os.path.join(tmp_dir, "level1/file1.txt"), "w") as f:
+                f.write("level1 content")
+            with open(os.path.join(tmp_dir, "level1/level2/file2.txt"), "w") as f:
+                f.write("level2 content")
+                
+            result = summarize_directory(tmp_dir, tree_depth=2, file_depth=2)
+            
+            # Check tree view shows both levels and file contents
+            self.assertIn("level1", result)
+            self.assertIn("file1.txt", result)
+            self.assertIn("level1 content", result)
+            self.assertNotIn("level2 content", result)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Works to resolve https://github.com/Maralai/SummarizeGPT/issues/5

This pull request includes multiple changes to the `summarizeGPT/summarizeGPT.py` file to add new functionality for controlling the depth of directory traversal. The most important changes include adding new parameters to existing functions, updating the `main` function to handle these new parameters, and modifying the directory traversal logic to respect the specified depth limits.

Enhancements to depth control:

* [`summarizeGPT/summarizeGPT.py`](diffhunk://#diff-49fbd4f09a51e9a0b079ce49d32f44c02ac65c6d38eeac3c6e35a86f46a49501L28-R42): Added `tree_depth` and `file_depth` parameters to the `summarize_directory` and `get_tree_view` functions to limit the depth of directory traversal. [[1]](diffhunk://#diff-49fbd4f09a51e9a0b079ce49d32f44c02ac65c6d38eeac3c6e35a86f46a49501L28-R42) [[2]](diffhunk://#diff-49fbd4f09a51e9a0b079ce49d32f44c02ac65c6d38eeac3c6e35a86f46a49501R52-R75)
* [`summarizeGPT/summarizeGPT.py`](diffhunk://#diff-49fbd4f09a51e9a0b079ce49d32f44c02ac65c6d38eeac3c6e35a86f46a49501R86-R89): Updated `get_file_contents` function to include `max_depth` parameter and modified the traversal logic to skip directories exceeding the specified depth.
* [`summarizeGPT/summarizeGPT.py`](diffhunk://#diff-49fbd4f09a51e9a0b079ce49d32f44c02ac65c6d38eeac3c6e35a86f46a49501R160-R165): Updated the `main` function to add new command-line arguments (`--max-depth`, `--tree-depth`, `--file-depth`) and handle these arguments appropriately. [[1]](diffhunk://#diff-49fbd4f09a51e9a0b079ce49d32f44c02ac65c6d38eeac3c6e35a86f46a49501R160-R165) [[2]](diffhunk://#diff-49fbd4f09a51e9a0b079ce49d32f44c02ac65c6d38eeac3c6e35a86f46a49501R179-R187)